### PR TITLE
Validate compatibility with LTS JDK versions (11, 17, 21)

### DIFF
--- a/src/main/java/edu/berkeley/cs186/database/Database.java
+++ b/src/main/java/edu/berkeley/cs186/database/Database.java
@@ -25,7 +25,11 @@ import edu.berkeley.cs186.database.query.expr.Expression;
 import edu.berkeley.cs186.database.recovery.ARIESRecoveryManager;
 import edu.berkeley.cs186.database.recovery.DummyRecoveryManager;
 import edu.berkeley.cs186.database.recovery.RecoveryManager;
-import edu.berkeley.cs186.database.table.*;
+import edu.berkeley.cs186.database.table.PageDirectory;
+import edu.berkeley.cs186.database.table.Record;
+import edu.berkeley.cs186.database.table.RecordId;
+import edu.berkeley.cs186.database.table.Schema;
+import edu.berkeley.cs186.database.table.Table;
 import edu.berkeley.cs186.database.table.stats.TableStats;
 
 import java.io.*;

--- a/src/main/java/edu/berkeley/cs186/database/databox/FloatDataBox.java
+++ b/src/main/java/edu/berkeley/cs186/database/databox/FloatDataBox.java
@@ -45,7 +45,7 @@ public class FloatDataBox extends DataBox {
 
     @Override
     public int hashCode() {
-        return new Float(f).hashCode();
+        return Float.hashCode(f);
     }
 
     @Override

--- a/src/main/java/edu/berkeley/cs186/database/databox/IntDataBox.java
+++ b/src/main/java/edu/berkeley/cs186/database/databox/IntDataBox.java
@@ -45,7 +45,7 @@ public class IntDataBox extends DataBox {
 
     @Override
     public int hashCode() {
-        return new Integer(i).hashCode();
+        return Integer.hashCode(i);
     }
 
     @Override

--- a/src/main/java/edu/berkeley/cs186/database/databox/LongDataBox.java
+++ b/src/main/java/edu/berkeley/cs186/database/databox/LongDataBox.java
@@ -45,7 +45,7 @@ public class LongDataBox extends DataBox {
 
     @Override
     public int hashCode() {
-        return new Long(l).hashCode();
+        return Long.hashCode(l);
     }
 
     @Override


### PR DESCRIPTION
Validated OpenJDK LTS versions against all Project 5 assignments from Fall 2024 (for details, see infra docs). Other than trivial changes to address compilation and warnings, only one test diverged for a handful of repositories running with OpenJDK 21.0.6.

During `restartAnalysis`, all three students created a copy of the transaction table before iterating over it. Iteration order on the cloned `HashMap` matches that of the `ConcurrentHashMap` in JDK11 and JDK17, but not in JDK21. The test assumes that transaction 2 (EndTransaction) is logged before transaction 4 (AbortTransaction) at the end of analysis, but this is not required.